### PR TITLE
Use slim stretch instead of alpine

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.3-alpine3.9 AS base
+FROM python:3.7.3-slim-stretch AS base
 
 RUN pip install -U pip
 

--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -5,9 +5,11 @@ RUN pip install -U pip
 # Build Stage
 FROM base AS build
 
-RUN apk update && apk add --no-cache --upgrade \
-    build-base \
-    gcc
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        gcc && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /wheels
 COPY requirements.txt .


### PR DESCRIPTION
* 알파인 리눅스에선 데비안 리눅스에서 사용하는 표준 C 라이브러리인 `glic`를 포팅한 `musl` C 라이브러리를 사용하는데 이게 완벽히 호환되지 않아 알파인 사용시 불편한 점이 많습니다.
* K8S에서 발생하는 DNS 이슈를 dns config로 고칠 수 있는데 이는 알파인 리눅스에서는 위의 이유로 동작하지 않습니다.
* 이미지 크기 자체도 별로 차이 안날 뿐더러 다른 리소스에 비해 코스트가 높지 않다고 생각합니다.