### PR TITLE
Ignore unused-variable option of pylint in app.py

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/app.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/app.py
@@ -18,15 +18,15 @@ def create_app(config: Configuration):
     )
 
     @app.listener('before_server_start')
-    async def init(app_, loop):
+    async def init(app_, loop):  # pylint: disable=unused-variable
         pass
 
     @app.listener('after_server_stop')
-    async def close(app_, loop):
+    async def close(app_, loop):  # pylint: disable=unused-variable
         pass
 
     @app.route('/')
-    async def index(_):
+    async def index(_):  # pylint: disable=unused-variable
         return response.text(f'{{ cookiecutter.project_name }} ({__version__})')
 
     app.blueprint(view.app)


### PR DESCRIPTION
`app.py` 에 있는 함수 중 `init` & `close` & `index` 에서 `unused-variable` lint error 가 발생합니다.
이를 해결하기 위해 해당 함수에서 `unused-variable` lint check 를 disalbe 하는 것을 제안드립니다.