### PR TITLE
Add Kubernetes Graceful Termination option

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/app.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/app.py
@@ -1,6 +1,7 @@
 from sanic import Sanic, response
 from sentry_sdk import init as init_sentry
 from sentry_sdk.integrations.sanic import SanicIntegration
+import asyncio
 
 from . import __version__, view
 from .config import Configuration
@@ -20,6 +21,11 @@ def create_app(config: Configuration):
     @app.listener('before_server_start')
     async def init(app_, loop):  # pylint: disable=unused-variable
         pass
+
+    @app.listener('before_server_stop')
+    async def wait_before_stopping_server(app, loop):  # pylint: disable=unused-variable
+        if config.before_graceful_termination > 0:
+            await asyncio.sleep(config.before_graceful_termination)  
 
     @app.listener('after_server_stop')
     async def close(app_, loop):  # pylint: disable=unused-variable

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/app.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/app.py
@@ -1,7 +1,8 @@
+import asyncio
+
 from sanic import Sanic, response
 from sentry_sdk import init as init_sentry
 from sentry_sdk.integrations.sanic import SanicIntegration
-import asyncio
 
 from . import __version__, view
 from .config import Configuration
@@ -23,9 +24,8 @@ def create_app(config: Configuration):
         pass
 
     @app.listener('before_server_stop')
-    async def wait_before_stopping_server(app, loop):  # pylint: disable=unused-variable
-        if config.before_graceful_termination > 0:
-            await asyncio.sleep(config.before_graceful_termination)  
+    async def wait_before_stopping_server(app_, loop):  # pylint: disable=unused-variable
+        await asyncio.sleep(config.before_graceful_termination)  
 
     @app.listener('after_server_stop')
     async def close(app_, loop):  # pylint: disable=unused-variable

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/config.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/config.py
@@ -18,6 +18,7 @@ class SentryConfiguration:
 class Configuration:
     debug: bool
     environment: Optional[str]
+    before_graceful_termination: int
     http: HTTPConfiguration
     sentry: SentryConfiguration
 
@@ -27,6 +28,7 @@ def init_config(d: dict = None) -> Configuration:
     return Configuration(
         d.get('{{ cookiecutter.package_name|upper }}_DEBUG', str(False)).upper() == str(True).upper(),
         d.get('{{ cookiecutter.package_name|upper }}_ENVIRONMENT'),
+        int(d.get('{{ cookiecutter.package_name|upper }}_BEFORE_GRACEFUL_TERMINATION', 10)),
         HTTPConfiguration(
             d.get('{{ cookiecutter.package_name|upper }}_HTTP_HOST', '0.0.0.0'),
             int(d.get('{{ cookiecutter.package_name|upper }}_HTTP_PORT', 8000)),


### PR DESCRIPTION
Add sleep before initializing graceful termination to solve dropping requests because of Kubernetes Service update delays. Including with new configuration option to disable or extend the default period of 10 seconds.